### PR TITLE
支持直接部署证书到AWS ACM

### DIFF
--- a/app/lib/DeployHelper.php
+++ b/app/lib/DeployHelper.php
@@ -1371,7 +1371,7 @@ class DeployHelper
             'name' => 'AWS',
             'class' => 2,
             'icon' => 'aws.ico',
-            'note' => '支持部署到Amazon CloudFront',
+            'note' => '支持部署到Amazon CloudFront、AWS Certificate Manager',
             'inputs' => [
                 'AccessKeyId' => [
                     'name' => 'AccessKeyId',
@@ -1401,14 +1401,24 @@ class DeployHelper
                     'type' => 'select',
                     'options' => [
                         ['value'=>'cloudfront', 'label'=>'CloudFront'],
+                        ['value'=>'acm', 'label'=>'AWS Certificate Manager'],
                     ],
-                    'value' => 'cloudfront',
+                    'value' => 'acm',
                     'required' => true,
                 ],
                 'distribution_id' => [
                     'name' => '分配ID',
                     'type' => 'input',
                     'placeholder' => 'distributions id',
+                    'show' => 'product==\'cloudfront\'',
+                    'required' => true,
+                ],
+                'acm_arn' => [
+                    'name' => 'ACM ARN',
+                    'type' => 'input',
+                    'placeholder' => '',
+                    'show' => 'product==\'acm\'',
+                    'note' => '在AWS Certificate Manager控制台查看证书的ARN',
                     'required' => true,
                 ],
             ],

--- a/app/lib/deploy/aws.php
+++ b/app/lib/deploy/aws.php
@@ -34,7 +34,8 @@ class aws implements DeployInterface
         $certInfo = openssl_x509_parse($fullchain, true);
         if (!$certInfo) throw new Exception('证书解析失败');
 
-        $cert_id = $this->get_cert_id($fullchain, $privatekey, $info['cert_id']);
+        $cert_id = isset($info['cert_id']) ? $info['cert_id'] : null;
+        $cert_id = $this->get_cert_id($fullchain, $privatekey, $cert_id, $config['cert_name']);
         usleep(500000);
 
         $client = new AWSClient($this->AccessKeyId, $this->SecretAccessKey, 'cloudfront.amazonaws.com', 'cloudfront', '2020-05-31', 'us-east-1', $this->proxy);


### PR DESCRIPTION
* AWS会自动将ACM更新后的证书下发到CloudFront等产品，因此只要更新ACM中的证书即可完成证书续期部署。
* 保留直接部署到CloudFront逻辑，副作用：创建多个CloudFront分配的部署任务也会创建多个ACM证书，且续期时是新增ACM证书，会造成ACM证书堆积。