### PR TITLE
修复部署证书到阿里云OSS失败

### DIFF
--- a/app/lib/deploy/aliyun.php
+++ b/app/lib/deploy/aliyun.php
@@ -236,7 +236,7 @@ class aliyun implements DeployInterface
         if (empty($config['oss_endpoint'])) throw new Exception('OSS Endpoint不能为空');
         if (empty($config['oss_bucket'])) throw new Exception('OSS Bucket不能为空');
         $client = new AliyunOSS($this->AccessKeyId, $this->AccessKeySecret, $config['oss_endpoint']);
-        $client->addBucketCnameCert($config['oss_bucket'], $config['domain'], $cert_id);
+        $client->addBucketCnameCert($config['oss_bucket'], $config['domain'], $cert_id . '-cn-hangzhou');
         $this->log('OSS域名 ' . $config['domain'] . ' 部署证书成功！');
     }
 


### PR DESCRIPTION
阿里云OSS的证书部署接口的certid实际上是CertIdentifier，带有后缀-cn-hangzhou，直接使用数字ID会报错。经观察发现后缀是固定的，就不使用接口获取了，直接拼接上去。

![image](https://github.com/user-attachments/assets/3e498b33-b17e-4d87-9c89-24bca33b203c)
